### PR TITLE
Bst 203 improve cmake interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,5 @@ cmake_minimum_required(VERSION 3.1.0)
 project(jsonrpc CXX)
 
 find_package(MBCMakeTools REQUIRED)
-find_package(JsonCpp REQUIRED)
 
 add_subdirectory(src/main/cpp)

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/main>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/main/include>
-        $<INSTALL_INTERFACE:include>)
+        $<INSTALL_INTERFACE:${HEADER_INSTALL_DIR}>)
 
 export_api(jsonrpc JSONRPC_API)
 

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+find_package(JsonCpp REQUIRED)
+
 set(headers
     jsonreader.h
     jsonrpcprivate.h)
@@ -12,20 +14,24 @@ set(sources
     jsonrpcprivate.cpp
     jsonrpcstream.cpp)
 
-include_directories("${PROJECT_SOURCE_DIR}/src/main")
-include_directories("${PROJECT_SOURCE_DIR}/src/main/include")
-
 add_compiler_flags()
 
 add_library(jsonrpc SHARED ${sources} ${headers})
 
+target_include_directories(
+    jsonrpc
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/main>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/main/include>
+        $<INSTALL_INTERFACE:include>)
+
 export_api(jsonrpc JSONRPC_API)
 
-target_link_libraries(jsonrpc JsonCpp::jsoncpp)
+target_link_libraries(jsonrpc PUBLIC JsonCpp::jsoncpp)
 
-install_config(
+generate_and_install_config(
     NAME JsonRpc
-    TARGET jsonrpc)
+    TARGETS jsonrpc)
 
 install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/src/main/include/jsonrpc"


### PR DESCRIPTION
This is an attempt to address the problem of repos depending on their installed
headers before their local headers. The way install_config sets include_dirs
in the *Config.cmake is sort of anti-social. We probably shouldn't be using
include_directories anywhere, really, since we can use target_include_dirs
instead.
