### PR TITLE
A critical fix of library crash and control sequence handling (\n)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.pdb
 *.vcxproj
 *.rc
+/install_manifest.txt

--- a/SConscript
+++ b/SConscript
@@ -7,6 +7,10 @@ env = Environment(
     tools=['default', 'mb_install'],
     toolpath=['#/../mw-scons-tools', '#/Install/mw-scons-tools'])
 
+debug = ARGUMENTS.get('debug', 0)
+if int(debug):
+    env.Append(CCFLAGS = '-g')
+
 env.MBAddStandardCompilerFlags()
 
 env.MBAddIncludePaths([

--- a/SConscript
+++ b/SConscript
@@ -2,14 +2,54 @@
 
 import os
 
+optCC = 'gcc'
+optCXX = 'g++'
+optAR = 'ar'
+optSTRIP = 'strip'
+
 env = Environment(
     ENV=os.environ,
     tools=['default', 'mb_install'],
     toolpath=['#/../mw-scons-tools', '#/Install/mw-scons-tools'])
 
 debug = ARGUMENTS.get('debug', 0)
+target = ARGUMENTS.get('target', 0)
+SYSROOT = ARGUMENTS.get('sysroot', 0)
+TCPREFIX = ARGUMENTS.get('tcprefix', 0)
+TCVERSION = ARGUMENTS.get('tcversion', 0)
+
+if SYSROOT!=0:
+	sysroot=SYSROOT
+
+if TCPREFIX!=0:
+	optCC=('%s-' % TCPREFIX) + optCC
+	optCXX=('%s-' % TCPREFIX) + optCXX
+	optAR=('%s-' % TCPREFIX) + optAR
+	optSTRIP=('%s-' % TCPREFIX) + optSTRIP
+	
+if TCVERSION!=0:
+	optCC=optCC + ('-%s' % TCVERSION)
+	optCXX=optCXX + ('-%s' % TCVERSION)
+	optAR=optAR + ('-%s' % TCPREFIX)
+	
+env_options = {
+    "CC"    : optCC,
+    "CXX"   : optCXX,
+    "LD"    : optCXX,
+    "AR"    : optAR,
+    "STRIP" : optSTRIP
+}
+
 if int(debug):
     env.Append(CCFLAGS = '-g')
+
+if target == 'arm':
+	env.Replace(**env_options)
+	if SYSROOT!=0:
+		env.Append(CCFLAGS=['--sysroot=%s' % sysroot],
+				   LINKFLAGS=['--sysroot=%s' % sysroot])			   
+		env.Append(CCFLAGS=['-I%s/usr/include/arm-linux-gnueabihf/c++/4.9' % sysroot])
+		env.Append(CCFLAGS=['-I%s/usr/include/c++/4.9' % sysroot])
 
 env.MBAddStandardCompilerFlags()
 

--- a/src/main/cpp/jsonreader.cpp
+++ b/src/main/cpp/jsonreader.cpp
@@ -41,6 +41,10 @@ void JsonReader::send() {
   m_jsonRpcPrivate.jsonReaderCallback(jsonText);
 }
 
+void JsonReader::setDelimiter(char ch){
+  m_packetDelimiter = ch;
+}
+
 bool JsonReader::transition(char const ch) {
   switch (m_state) {
     case S0:
@@ -96,6 +100,8 @@ void JsonReader::feed(char ch) {
   m_buffer << ch;
   if(transition(ch))
 	  send();
+  else if(m_packetDelimiter == ch) //use delimiter as sync sequence. we assume that json is passed as minified string
+    return send();
 }
 
 void JsonReader::feed(char const * const buffer, std::size_t const length) {

--- a/src/main/cpp/jsonreader.h
+++ b/src/main/cpp/jsonreader.h
@@ -24,7 +24,7 @@ class JsonReader : public JsonRpcStream {
   enum State { S0, S1, S2, S3 };
 
   void reset(void);
-  void transition(char ch);
+  bool transition(char ch);
   void send(void);
 
   JsonRpcPrivate & m_jsonRpcPrivate;

--- a/src/main/cpp/jsonreader.h
+++ b/src/main/cpp/jsonreader.h
@@ -19,6 +19,7 @@ class JsonReader : public JsonRpcStream {
   JSONRPC_API void feed(char const *, std::size_t);
   JSONRPC_API void feed(std::string const &);
   JSONRPC_API void feedeof(void);
+  JSONRPC_API void setDelimiter(char);
 
  private:
   enum State { S0, S1, S2, S3 };
@@ -31,6 +32,7 @@ class JsonReader : public JsonRpcStream {
   State m_state;
   std::stack <char> m_stack;
   std::ostringstream m_buffer;
+  char m_packetDelimiter = '\n'; //by default use \n char as sync sequence
 
   // Disable copy constructor and assignment.
 

--- a/src/main/cpp/jsonrpcprivate.cpp
+++ b/src/main/cpp/jsonrpcprivate.cpp
@@ -295,9 +295,9 @@ void JsonRpcPrivate::handleResponse(
     if (i != m_callbacks.end()) {
       // Get the shared pointer to the callback
       callback = i->second.lock();
+      // Remove the weak pointer to the callback
+      m_callbacks.erase(i);
     }
-    // Remove the weak pointer to the callback
-    m_callbacks.erase(i);
   }
 
   // If the callback is still valid, send the response
@@ -312,7 +312,7 @@ Json::Value JsonRpcPrivate::handleObject(Json::Value const & jsonObject) {
     Json::Value const null;
     response = invalidRequest(null);
   } else {
-    Json::Value const id(jsonObject["id"]);
+    Json::Value const id(jsonObject["id"]); //TODO: handle special responses (e.g. parse errors)
     if (isRequest(jsonObject)) {
       response = handleRequest(jsonObject, id);
     } else if (isResponse(jsonObject)) {


### PR DESCRIPTION
There was deletion of m_callbacks.end() when receiving "parse error" string, that lead to segfault of the app.

Also, a single \n, or a \n at the end of the json string was triggering json parsing one more time.

sometimes, under severe load (millions requests per hour) and unstable transmission line you can run into loss of synchronization of the stream. JSON stream parsing state machine adds '{' to stack, but end sequence of } can be lost. That leads to endless stream bufferization in parser. To avoid this, a delimiter was implemented, that resets stream parser to initial state after. If delimiter is not used, it can be set to \0
