### PR TITLE
Using TRANSITIVE_DEPENDENCIES in cmake

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -31,7 +31,8 @@ target_link_libraries(jsonrpc PUBLIC JsonCpp::jsoncpp)
 
 generate_and_install_config(
     NAME JsonRpc
-    TARGETS jsonrpc)
+    TARGETS jsonrpc
+    TRANSITIVE_DEPENDENCIES "JsonCpp REQUIRED")
 
 install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/src/main/include/jsonrpc"


### PR DESCRIPTION
Since consumers of JsonRpc can't use it without using JsonCpp.

BST-341
http://jira.makerbot.net/browse/BST-341
